### PR TITLE
feat: add local Obsidian notes intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ Sample prompts per tool: [`docs/tools.md`](./docs/tools.md).
 
 ---
 
+## Local Obsidian notes intake
+
+aftercall can also sit next to a local Obsidian vault for personal note dumps.
+This path is local-only: Codex organizes the messy input, then
+`scripts/obsidian-intake.ts` writes Obsidian Markdown into your vault.
+
+```bash
+export OBSIDIAN_VAULT="$HOME/path/to/your/Obsidian Vault"
+npm run notes:intake -- --bootstrap
+pbpaste | npm run notes:intake -- --title "Planning dump"
+```
+
+Details and the structured Codex plan format: [`docs/obsidian-intake.md`](./docs/obsidian-intake.md).
+
+---
+
 ## Architecture
 
 Three flows compose the system. Each has its own diagram and runbook:
@@ -350,4 +366,3 @@ Not promises — just ideas on the shortlist. File an issue if you want to prior
 ## License
 
 MIT — see [LICENSE](./LICENSE).
-

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -6,7 +6,7 @@ Tracks are the logical unit of work in aftercall. Each track has a spec (why + w
 
 | Status | Track ID | Title | Created | Updated |
 | ------ | -------- | ----- | ------- | ------- |
-| _none_ | | | | |
+| 🚧 active | [personal-notes-intake](./tracks/personal-notes-intake/) | Local Obsidian notes intake from Codex dumps | 2026-04-27 | 2026-04-27 |
 
 ## Completed
 

--- a/conductor/tracks/personal-notes-intake/spec.md
+++ b/conductor/tracks/personal-notes-intake/spec.md
@@ -1,0 +1,79 @@
+# Personal Notes Intake
+
+## Status
+
+Active
+
+## Problem
+
+aftercall captures meeting context, but loose thoughts, priorities, project notes,
+and follow-up ideas still live outside the system. The user wants to dump raw
+notes into a Codex agent and have those notes land in a local Obsidian vault in a
+useful shape without learning an elaborate Obsidian workflow first.
+
+## Goals
+
+- Preserve every raw dump so nothing is lost.
+- Let Codex do the interpretation work and let a script do deterministic vault
+  writes.
+- Create Obsidian-native Markdown with properties, wikilinks, tasks, project
+  notes, people notes, decision notes, and lightweight dashboards.
+- Keep the first version local-only and independent of Cloudflare, Notion, and
+  aftercall's production ingestion path.
+
+## Non-goals
+
+- Build an Obsidian plugin.
+- Sync the entire vault into D1 or Vectorize.
+- Rewrite or reorganize existing vault content automatically.
+- Merge aftercall meeting transcripts into Obsidian in this phase.
+
+## Design
+
+The flow is intentionally small:
+
+1. User dumps notes into Codex.
+2. Codex converts the dump into an `IntakePlan` JSON object.
+3. `scripts/obsidian-intake.ts` writes the plan into a local vault.
+4. Obsidian displays the resulting Markdown and Base dashboards.
+
+The script writes:
+
+- `Inbox/Dumps/<date time - title>.md` for the raw dump.
+- `Inbox/<date>.md` as the daily capture stream.
+- `Next Actions.md` for extracted tasks.
+- `Projects/<name>.md` for project updates.
+- `People/<name>.md` for person context.
+- `Decisions/<date - title>.md` for durable decisions.
+- `Dashboards/*.base` for lightweight project/action views.
+
+## Phases
+
+### Phase 1: Local Writer
+
+- Add typed intake document builders.
+- Add tests for raw dump preservation, task formatting, wikilinks, project
+  updates, people updates, decision notes, and dashboard templates.
+- Add a CLI that writes the generated documents to a vault path supplied by
+  `--vault` or `OBSIDIAN_VAULT`.
+
+### Phase 2: Codex Skill
+
+- Install a local Codex skill that turns messy user input into the `IntakePlan`
+  shape and runs the writer.
+- Keep the skill conservative: preserve raw text, append to existing notes, and
+  never delete vault content.
+
+### Phase 3: aftercall Bridge
+
+- Later, add an explicit bridge from indexed meetings to Obsidian project/person
+  notes. This should reuse the same writer contract so meetings and note dumps
+  converge on one vault shape.
+
+## Decisions
+
+- Use Obsidian as the human-readable source of truth for notes.
+- Keep aftercall's deployed Worker untouched in the first phase.
+- Avoid direct Obsidian plugin work until the local writer proves useful.
+- Store generated tasks as plain Markdown tasks so Obsidian can render and query
+  them without a dependency on a task plugin.

--- a/docs/obsidian-intake.md
+++ b/docs/obsidian-intake.md
@@ -1,0 +1,104 @@
+# Obsidian Notes Intake
+
+This is the local-first bridge between messy Codex dumps and an Obsidian vault.
+It does not touch the deployed Worker, D1, Vectorize, Notion, or aftercall's
+meeting ingestion path.
+
+## Quick Start
+
+The script auto-detects the currently open Obsidian vault on macOS. You can also
+set your vault path explicitly:
+
+```bash
+export OBSIDIAN_VAULT="$HOME/path/to/your/Obsidian Vault"
+```
+
+Bootstrap the lightweight dashboards:
+
+```bash
+npm run notes:intake -- --bootstrap
+```
+
+Capture a raw dump:
+
+```bash
+pbpaste | npm run notes:intake -- --title "Monday planning dump"
+```
+
+The script writes to:
+
+- `Inbox/Dumps/` for preserved raw dumps
+- `Inbox/YYYY-MM-DD.md` for daily captures
+- `Next Actions.md` for extracted action items
+- `Projects/` for project notes
+- `People/` for person notes
+- `Decisions/` for durable decisions
+- `Dashboards/` for Obsidian Bases views
+
+## Codex Intake Plan
+
+For best results, have Codex turn a messy dump into this JSON shape and pass it
+with `--plan`:
+
+```json
+{
+  "title": "Monday planning dump",
+  "dump": "The original raw text goes here.",
+  "summary": "Short summary of what changed.",
+  "tags": ["planning"],
+  "projects": [
+    {
+      "name": "Project Atlas",
+      "status": "active",
+      "summary": "The project needs a cleaner next-action list.",
+      "notes": ["Budget and review timing are still fuzzy."],
+      "nextActions": ["Draft the first project review outline"]
+    }
+  ],
+  "people": [
+    {
+      "name": "Sarah",
+      "notes": ["Waiting for review timing."],
+      "nextActions": ["Ask Sarah for review timing"]
+    }
+  ],
+  "tasks": [
+    {
+      "text": "Follow up with Sarah about review timing",
+      "project": "Project Atlas",
+      "person": "Sarah",
+      "due": "2026-04-30",
+      "priority": "high"
+    }
+  ],
+  "decisions": [
+    {
+      "title": "Use Obsidian as the notes source of truth",
+      "project": "Project Atlas",
+      "decision": "Keep organized notes in Obsidian and index them later.",
+      "rationale": "This gives value before adding a full sync/indexing layer."
+    }
+  ]
+}
+```
+
+Run it:
+
+```bash
+npm run notes:intake -- --plan /tmp/intake-plan.json
+```
+
+Preview without writing:
+
+```bash
+npm run notes:intake -- --plan /tmp/intake-plan.json --dry-run
+```
+
+## Safety Rules
+
+- Raw dumps are always preserved.
+- Existing project, person, daily, and task files are appended to, not rewritten.
+- Existing decision and raw dump files are skipped on path collision.
+- Generated paths are constrained to the configured vault directory.
+- The script works with plain Markdown and Obsidian Bases; no Obsidian plugin is
+  required.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "node scripts/deploy.mjs",
+    "notes:intake": "node scripts/obsidian-intake.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/scripts/obsidian-intake.ts
+++ b/scripts/obsidian-intake.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Write a Codex-organized notes dump into a local Obsidian vault.
+ *
+ * Best path:
+ *   1. Codex turns a messy dump into the JSON IntakePlan shape below.
+ *   2. This script performs the boring, safe file writes.
+ *
+ *   OBSIDIAN_VAULT="$HOME/Documents/My Vault" \
+ *   npm run notes:intake -- --plan /tmp/intake-plan.json
+ *
+ * Plain text fallback:
+ *   echo "messy notes..." | npm run notes:intake -- --vault "$OBSIDIAN_VAULT" --title "Brain dump"
+ */
+import { constants } from "node:fs";
+import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { stdin } from "node:process";
+import { parseArgs } from "node:util";
+import {
+  buildBootstrapDocuments,
+  buildIntakeDocuments,
+  type IntakeDocument,
+  type IntakePlan,
+} from "../src/obsidian/intake.ts";
+
+interface WriteResult {
+  path: string;
+  action: "created" | "appended" | "skipped";
+}
+
+const { values } = parseArgs({
+  options: {
+    vault: { type: "string" },
+    plan: { type: "string" },
+    dump: { type: "string" },
+    title: { type: "string" },
+    bootstrap: { type: "boolean", default: false },
+    "dry-run": { type: "boolean", default: false },
+  },
+});
+
+async function main(): Promise<void> {
+  const vaultPath = values.vault ?? process.env.OBSIDIAN_VAULT ?? (await detectObsidianVault());
+  if (!vaultPath) {
+    fail("Set --vault or OBSIDIAN_VAULT to your local Obsidian vault path.");
+  }
+
+  const vault = resolve(expandHome(vaultPath));
+  await ensureDirectory(vault, "Obsidian vault");
+
+  const docs = values.bootstrap
+    ? buildBootstrapDocuments()
+    : buildIntakeDocuments(await loadPlan());
+
+  if (values["dry-run"]) {
+    console.log(JSON.stringify({ dryRun: true, vault, documents: docs }, null, 2));
+    return;
+  }
+
+  const results: WriteResult[] = [];
+  for (const doc of docs) {
+    results.push(await writeDocument(vault, doc));
+  }
+
+  console.log(JSON.stringify({ vault, results }, null, 2));
+}
+
+async function loadPlan(): Promise<IntakePlan> {
+  if (values.plan) {
+    const raw = await readFile(expandHome(values.plan), "utf8");
+    return validatePlan(JSON.parse(raw));
+  }
+
+  const dump = values.dump
+    ? await readFile(expandHome(values.dump), "utf8")
+    : await readStdin();
+
+  if (!dump.trim()) {
+    fail("Provide --plan, --dump, or pipe raw notes into stdin.");
+  }
+
+  return {
+    title: values.title,
+    dump,
+  };
+}
+
+async function writeDocument(vault: string, doc: IntakeDocument): Promise<WriteResult> {
+  const target = resolveInsideVault(vault, doc.path);
+  await mkdir(dirname(target), { recursive: true });
+
+  if (doc.mode === "create") {
+    if (await exists(target)) return { path: doc.path, action: "skipped" };
+    await writeFile(target, ensureTrailingNewline(doc.createContent), "utf8");
+    return { path: doc.path, action: "created" };
+  }
+
+  if (await exists(target)) {
+    await appendFile(target, ensureLeadingNewline(doc.appendContent ?? ""), "utf8");
+    return { path: doc.path, action: "appended" };
+  }
+
+  await writeFile(target, ensureTrailingNewline(doc.createContent), "utf8");
+  return { path: doc.path, action: "created" };
+}
+
+function validatePlan(value: unknown): IntakePlan {
+  if (!value || typeof value !== "object") fail("Plan JSON must be an object.");
+  const plan = value as Partial<IntakePlan>;
+  if (typeof plan.dump !== "string" || !plan.dump.trim()) {
+    fail("Plan JSON must include a non-empty string field: dump.");
+  }
+  return plan as IntakePlan;
+}
+
+async function readStdin(): Promise<string> {
+  if (stdin.isTTY) return "";
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function ensureDirectory(path: string, label: string): Promise<void> {
+  try {
+    await access(path, constants.R_OK | constants.W_OK);
+  } catch {
+    fail(`${label} does not exist or is not writable: ${path}`);
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveInsideVault(vault: string, relativePath: string): string {
+  if (isAbsolute(relativePath)) fail(`Document paths must be vault-relative: ${relativePath}`);
+  const target = resolve(vault, relativePath);
+  if (target !== vault && !target.startsWith(`${vault}${sep}`)) {
+    fail(`Document path escapes the vault: ${relativePath}`);
+  }
+  return target;
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return process.env.HOME ?? path;
+  if (path.startsWith("~/")) return join(process.env.HOME ?? "", path.slice(2));
+  return path;
+}
+
+async function detectObsidianVault(): Promise<string | undefined> {
+  const configPath = join(homedir(), "Library", "Application Support", "obsidian", "obsidian.json");
+  try {
+    const raw = await readFile(configPath, "utf8");
+    const config = JSON.parse(raw) as {
+      vaults?: Record<string, { path?: string; ts?: number; open?: boolean }>;
+    };
+    const vaults = Object.values(config.vaults ?? {})
+      .filter((vault): vault is { path: string; ts?: number; open?: boolean } => Boolean(vault.path))
+      .sort((a, b) => {
+        if (a.open !== b.open) return a.open ? -1 : 1;
+        return (b.ts ?? 0) - (a.ts ?? 0);
+      });
+    return vaults[0]?.path;
+  } catch {
+    return undefined;
+  }
+}
+
+function ensureLeadingNewline(content: string): string {
+  const withTrailing = ensureTrailingNewline(content);
+  return withTrailing.startsWith("\n") ? withTrailing : `\n${withTrailing}`;
+}
+
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/obsidian/intake.test.ts
+++ b/src/obsidian/intake.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBootstrapDocuments,
+  buildIntakeDocuments,
+  sanitizeNoteName,
+} from "./intake";
+
+const NOW = new Date(2026, 3, 27, 15, 4, 5);
+
+describe("obsidian intake documents", () => {
+  it("preserves the raw dump and appends an organized daily capture", () => {
+    const docs = buildIntakeDocuments(
+      {
+        title: "Monday planning / messy dump",
+        dump: "I need to clean up Project Atlas and follow up with Sarah.",
+        summary: "Project Atlas needs cleanup and Sarah needs a follow-up.",
+        tags: ["planning", "work notes"],
+        tasks: [
+          {
+            text: "Follow up with Sarah about Project Atlas",
+            project: "Project Atlas",
+            person: "Sarah",
+            due: "2026-04-30",
+            priority: "high",
+          },
+        ],
+      },
+      { now: NOW },
+    );
+
+    expect(docs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "Inbox/Dumps/2026-04-27 1504 - Monday planning messy dump.md",
+          mode: "create",
+        }),
+        expect.objectContaining({
+          path: "Inbox/2026-04-27.md",
+          mode: "append-or-create",
+        }),
+        expect.objectContaining({
+          path: "Next Actions.md",
+          mode: "append-or-create",
+        }),
+      ]),
+    );
+
+    const rawDump = docs.find((doc) => doc.path.startsWith("Inbox/Dumps/"));
+    expect(rawDump?.createContent).toContain("type: dump");
+    expect(rawDump?.createContent).toContain("# Monday planning / messy dump");
+    expect(rawDump?.createContent).toContain("## Raw Dump");
+    expect(rawDump?.createContent).toContain("I need to clean up Project Atlas");
+
+    const nextActions = docs.find((doc) => doc.path === "Next Actions.md");
+    expect(nextActions?.appendContent).toContain(
+      "- [ ] Follow up with Sarah about Project Atlas (due: 2026-04-30) (priority: high) [[Project Atlas]] [[Sarah]]",
+    );
+  });
+
+  it("creates project, person, and decision updates with wikilinks", () => {
+    const docs = buildIntakeDocuments(
+      {
+        title: "Solar ops notes",
+        dump: "Decided to make intake the source of truth.",
+        projects: [
+          {
+            name: "Solar Ops",
+            status: "active",
+            summary: "Intake workflow is becoming the source of truth.",
+            notes: ["Move scattered notes into one project surface."],
+            nextActions: ["Draft the first intake workflow"],
+          },
+        ],
+        people: [
+          {
+            name: "Jamie Chen",
+            notes: ["Owns project review feedback."],
+            nextActions: ["Ask Jamie for review timing"],
+          },
+        ],
+        decisions: [
+          {
+            title: "Use Obsidian as the notes source of truth",
+            project: "Solar Ops",
+            decision: "Keep organized notes in Obsidian and index them later.",
+            rationale: "This keeps the local vault useful before building sync.",
+          },
+        ],
+      },
+      { now: NOW },
+    );
+
+    expect(docs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "Projects/Solar Ops.md" }),
+        expect.objectContaining({ path: "People/Jamie Chen.md" }),
+        expect.objectContaining({
+          path: "Decisions/2026-04-27 - Use Obsidian as the notes source of truth.md",
+        }),
+      ]),
+    );
+
+    const project = docs.find((doc) => doc.path === "Projects/Solar Ops.md");
+    expect(project?.createContent).toContain("status: active");
+    expect(project?.appendContent).toContain("[[Inbox/Dumps/2026-04-27 1504 - Solar ops notes]]");
+    expect(project?.appendContent).toContain("- [ ] Draft the first intake workflow");
+
+    const decision = docs.find((doc) => doc.path.startsWith("Decisions/"));
+    expect(decision?.createContent).toContain("project: \"[[Solar Ops]]\"");
+    expect(decision?.createContent).toContain("Keep organized notes in Obsidian");
+  });
+
+  it("sanitizes note names without flattening readable spaces", () => {
+    expect(sanitizeNoteName("  ACME: Design/Build? <Plan>  ")).toBe("ACME DesignBuild Plan");
+    expect(sanitizeNoteName("")).toBe("Untitled");
+  });
+});
+
+describe("obsidian bootstrap documents", () => {
+  it("creates base dashboards for projects and actions", () => {
+    const docs = buildBootstrapDocuments();
+
+    expect(docs.map((doc) => doc.path)).toEqual([
+      "Dashboards/Active Projects.base",
+      "Dashboards/Next Actions.base",
+      "Dashboards/Waiting On.base",
+    ]);
+    expect(docs[0].createContent).toContain('file.inFolder("Projects")');
+    expect(docs[1].createContent).toContain('file.hasTag("task")');
+  });
+});

--- a/src/obsidian/intake.ts
+++ b/src/obsidian/intake.ts
@@ -1,0 +1,418 @@
+export interface IntakeTask {
+  text: string;
+  project?: string;
+  person?: string;
+  due?: string;
+  priority?: "low" | "medium" | "high";
+  status?: "todo" | "doing" | "done";
+}
+
+export interface IntakeProject {
+  name: string;
+  status?: "active" | "paused" | "waiting" | "done";
+  summary?: string;
+  notes?: string[];
+  nextActions?: string[];
+}
+
+export interface IntakePerson {
+  name: string;
+  summary?: string;
+  notes?: string[];
+  nextActions?: string[];
+}
+
+export interface IntakeDecision {
+  title: string;
+  project?: string;
+  decision: string;
+  rationale?: string;
+}
+
+export interface IntakePlan {
+  title?: string;
+  dump: string;
+  summary?: string;
+  tags?: string[];
+  projects?: IntakeProject[];
+  people?: IntakePerson[];
+  tasks?: IntakeTask[];
+  decisions?: IntakeDecision[];
+}
+
+export interface IntakeDocument {
+  path: string;
+  mode: "create" | "append-or-create";
+  createContent: string;
+  appendContent?: string;
+}
+
+interface BuildOptions {
+  now?: Date;
+}
+
+const DEFAULT_TITLE = "Notes dump";
+
+export function sanitizeNoteName(input: string): string {
+  const cleaned = input
+    .trim()
+    .replace(/[\\/:*?"<>|[\]^#]/g, "")
+    .replace(/\s+/g, " ")
+    .slice(0, 120)
+    .trim();
+  return cleaned || "Untitled";
+}
+
+export function buildIntakeDocuments(plan: IntakePlan, options: BuildOptions = {}): IntakeDocument[] {
+  const now = options.now ?? new Date();
+  const date = toDate(now);
+  const time = toTime(now);
+  const title = plan.title?.trim() || DEFAULT_TITLE;
+  const safeTitle = sanitizeNoteName(title);
+  const rawDumpPath = `Inbox/Dumps/${date} ${time.replace(":", "")} - ${safeTitle}.md`;
+  const summary = plan.summary?.trim();
+  const tags = normalizeTags(["inbox/dump", "context/intake", ...(plan.tags ?? [])]);
+  const docs: IntakeDocument[] = [
+    {
+      path: rawDumpPath,
+      mode: "create",
+      createContent: [
+        frontmatter({
+          title,
+          date,
+          type: "dump",
+          source: "codex",
+          tags,
+        }),
+        `# ${title}`,
+        "",
+        summary ? "## Summary" : "",
+        summary ? summary : "",
+        summary ? "" : "",
+        "## Raw Dump",
+        "",
+        plan.dump.trim(),
+        "",
+        relatedLinks(plan),
+      ]
+        .filter((line) => line !== "")
+        .join("\n"),
+    },
+  ];
+
+  docs.push(buildDailyDocument(plan, { date, time, title, rawDumpPath, summary }));
+
+  if (plan.tasks?.length) {
+    docs.push(buildNextActionsDocument(plan.tasks, { date, title, rawDumpPath }));
+  }
+
+  for (const project of plan.projects ?? []) {
+    docs.push(buildProjectDocument(project, { date, rawDumpPath }));
+  }
+
+  for (const person of plan.people ?? []) {
+    docs.push(buildPersonDocument(person, { date, rawDumpPath }));
+  }
+
+  for (const decision of plan.decisions ?? []) {
+    docs.push(buildDecisionDocument(decision, { date, rawDumpPath }));
+  }
+
+  return docs;
+}
+
+export function buildBootstrapDocuments(): IntakeDocument[] {
+  return [
+    {
+      path: "Dashboards/Active Projects.base",
+      mode: "create",
+      createContent: [
+        'filters: \'file.inFolder("Projects") && status != "done"\'',
+        "views:",
+        "  - type: table",
+        '    name: "Active Projects"',
+        "    order:",
+        "      - file.name",
+        "      - status",
+        "      - priority",
+        "      - file.mtime",
+        "",
+      ].join("\n"),
+    },
+    {
+      path: "Dashboards/Next Actions.base",
+      mode: "create",
+      createContent: [
+        'filters: \'file.hasTag("task")\'',
+        "views:",
+        "  - type: table",
+        '    name: "Next Actions"',
+        "    order:",
+        "      - file.name",
+        "      - file.folder",
+        "      - due",
+        "      - priority",
+        "",
+      ].join("\n"),
+    },
+    {
+      path: "Dashboards/Waiting On.base",
+      mode: "create",
+      createContent: [
+        'filters: \'status == "waiting" || file.hasTag("waiting")\'',
+        "views:",
+        "  - type: table",
+        '    name: "Waiting On"',
+        "    order:",
+        "      - file.name",
+        "      - owner",
+        "      - file.mtime",
+        "",
+      ].join("\n"),
+    },
+  ];
+}
+
+function buildDailyDocument(
+  plan: IntakePlan,
+  context: { date: string; time: string; title: string; rawDumpPath: string; summary?: string },
+): IntakeDocument {
+  const tasks = plan.tasks ?? [];
+  const appendContent = [
+    "",
+    `## ${context.time} - ${context.title}`,
+    "",
+    `Source: [[${noteTarget(context.rawDumpPath)}]]`,
+    context.summary ? `Summary: ${context.summary}` : "",
+    tasks.length ? "" : "",
+    tasks.length ? "### Next Actions" : "",
+    ...tasks.map(formatTask),
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+
+  return {
+    path: `Inbox/${context.date}.md`,
+    mode: "append-or-create",
+    createContent: [
+      frontmatter({
+        title: `Inbox ${context.date}`,
+        date: context.date,
+        type: "daily-inbox",
+        tags: ["inbox/daily"],
+      }),
+      `# Inbox ${context.date}`,
+      appendContent,
+    ].join("\n"),
+    appendContent,
+  };
+}
+
+function buildNextActionsDocument(
+  tasks: IntakeTask[],
+  context: { date: string; title: string; rawDumpPath: string },
+): IntakeDocument {
+  const appendContent = [
+    "",
+    `## ${context.date} - ${context.title}`,
+    "",
+    `Source: [[${noteTarget(context.rawDumpPath)}]]`,
+    ...tasks.map(formatTask),
+    "",
+  ].join("\n");
+
+  return {
+    path: "Next Actions.md",
+    mode: "append-or-create",
+    createContent: [
+      frontmatter({
+        title: "Next Actions",
+        type: "task-index",
+        tags: ["task"],
+      }),
+      "# Next Actions",
+      appendContent,
+    ].join("\n"),
+    appendContent,
+  };
+}
+
+function buildProjectDocument(
+  project: IntakeProject,
+  context: { date: string; rawDumpPath: string },
+): IntakeDocument {
+  const name = sanitizeNoteName(project.name);
+  const appendContent = [
+    "",
+    `## Update ${context.date}`,
+    "",
+    `Source: [[${noteTarget(context.rawDumpPath)}]]`,
+    project.summary ? `Summary: ${project.summary}` : "",
+    listSection("Notes", project.notes),
+    listSection("Next Actions", project.nextActions, "- [ ]"),
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    path: `Projects/${name}.md`,
+    mode: "append-or-create",
+    createContent: [
+      frontmatter({
+        title: project.name,
+        type: "project",
+        status: project.status ?? "active",
+        tags: ["project"],
+      }),
+      `# ${project.name}`,
+      appendContent,
+    ].join("\n"),
+    appendContent,
+  };
+}
+
+function buildPersonDocument(
+  person: IntakePerson,
+  context: { date: string; rawDumpPath: string },
+): IntakeDocument {
+  const name = sanitizeNoteName(person.name);
+  const appendContent = [
+    "",
+    `## Update ${context.date}`,
+    "",
+    `Source: [[${noteTarget(context.rawDumpPath)}]]`,
+    person.summary ? `Summary: ${person.summary}` : "",
+    listSection("Notes", person.notes),
+    listSection("Next Actions", person.nextActions, "- [ ]"),
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return {
+    path: `People/${name}.md`,
+    mode: "append-or-create",
+    createContent: [
+      frontmatter({
+        title: person.name,
+        type: "person",
+        tags: ["person"],
+      }),
+      `# ${person.name}`,
+      appendContent,
+    ].join("\n"),
+    appendContent,
+  };
+}
+
+function buildDecisionDocument(
+  decision: IntakeDecision,
+  context: { date: string; rawDumpPath: string },
+): IntakeDocument {
+  const title = sanitizeNoteName(decision.title);
+  return {
+    path: `Decisions/${context.date} - ${title}.md`,
+    mode: "create",
+    createContent: [
+      frontmatter({
+        title: decision.title,
+        date: context.date,
+        type: "decision",
+        project: decision.project ? `[[${sanitizeNoteName(decision.project)}]]` : undefined,
+        tags: ["decision"],
+      }),
+      `# ${decision.title}`,
+      "",
+      `Source: [[${noteTarget(context.rawDumpPath)}]]`,
+      "",
+      "## Decision",
+      "",
+      decision.decision,
+      decision.rationale ? "" : "",
+      decision.rationale ? "## Rationale" : "",
+      decision.rationale ? "" : "",
+      decision.rationale ?? "",
+      "",
+    ]
+      .filter((line) => line !== "")
+      .join("\n"),
+  };
+}
+
+function formatTask(task: IntakeTask): string {
+  const checkbox = task.status === "done" ? "[x]" : "[ ]";
+  const due = task.due ? ` (due: ${task.due})` : "";
+  const priority = task.priority ? ` (priority: ${task.priority})` : "";
+  const project = task.project ? ` [[${sanitizeNoteName(task.project)}]]` : "";
+  const person = task.person ? ` [[${sanitizeNoteName(task.person)}]]` : "";
+  return `- ${checkbox} ${task.text}${due}${priority}${project}${person}`;
+}
+
+function relatedLinks(plan: IntakePlan): string {
+  const links = [
+    ...(plan.projects ?? []).map((project) => `[[${sanitizeNoteName(project.name)}]]`),
+    ...(plan.people ?? []).map((person) => `[[${sanitizeNoteName(person.name)}]]`),
+  ];
+  if (links.length === 0) return "";
+  return ["## Related", "", links.join(" ")].join("\n");
+}
+
+function listSection(title: string, items: string[] | undefined, marker = "-"): string {
+  if (!items?.length) return "";
+  return [`### ${title}`, ...items.map((item) => `${marker} ${item}`), ""].join("\n");
+}
+
+function toDate(date: Date): string {
+  return [
+    date.getFullYear(),
+    pad2(date.getMonth() + 1),
+    pad2(date.getDate()),
+  ].join("-");
+}
+
+function toTime(date: Date): string {
+  return [pad2(date.getHours()), pad2(date.getMinutes())].join(":");
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function noteTarget(path: string): string {
+  return path.replace(/\.md$/, "");
+}
+
+function normalizeTags(tags: string[]): string[] {
+  return tags
+    .map((tag) =>
+      tag
+        .trim()
+        .toLowerCase()
+        .replace(/^#/, "")
+        .replace(/[^a-z0-9/_-]+/g, "-")
+        .replace(/^-+|-+$/g, ""),
+    )
+    .filter(Boolean);
+}
+
+function frontmatter(values: Record<string, string | string[] | undefined>): string {
+  const lines = ["---"];
+  for (const [key, value] of Object.entries(values)) {
+    if (value == null) continue;
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) lines.push(`  - ${quoteYaml(item)}`);
+    } else {
+      lines.push(`${key}: ${quoteYaml(value)}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function quoteYaml(value: string): string {
+  if (/^[a-z0-9/_-]+$/i.test(value)) return value;
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
## Summary

- Adds a local Obsidian notes intake writer for Codex-organized brain dumps.
- Preserves raw dumps and appends structured updates to daily inbox, next actions, project, people, and decision notes.
- Adds Obsidian Bases dashboard templates for active projects, next actions, and waiting-on views.
- Documents the workflow and tracks the work in Conductor.

## Why

The user needs a low-lift way to dump scattered thoughts into Codex and have Obsidian become organized without learning a complex vault workflow first. This keeps the first version local-only and separate from the deployed Worker.

## User impact

After setting or auto-detecting a local vault, the user can run `npm run notes:intake` with a structured plan, or have Codex generate that plan from a messy note dump. The writer only creates or appends files and avoids deleting/reorganizing existing vault content.

## Validation

- `npx vitest run`
- `npx tsc --noEmit`
- Smoke-tested `npm run notes:intake -- --bootstrap` against the detected local Obsidian vault.

## Notes

Draft PR for review before merge. This intentionally does not include the local Codex skill installed under `~/.codex/skills` because that lives outside the repository.