### PR TITLE
feat: make Notion integration optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aftercall",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aftercall",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@cloudflare/workers-oauth-provider": "^0.4.0",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -361,6 +361,27 @@ async function step5_setupNotion(
 }> {
   header("[5/10] Notion setup");
 
+  // Opt-out path — Notion is optional. When skipped, the handler no-ops Notion
+  // writes (pipeline still ingests to D1 + Vectorize) and the list_followups
+  // MCP tool returns a "not configured" message.
+  const wantNotion = (
+    await rl.question(
+      "  Enable Notion integration (transcript pages + followups inbox)? (y/N): ",
+    )
+  )
+    .trim()
+    .toLowerCase();
+  if (wantNotion !== "y" && wantNotion !== "yes") {
+    ok(`Skipping Notion — pipeline will ingest to D1 + Vectorize only`);
+    return {
+      token: "",
+      transcriptsDbId: "",
+      followupsDbId: "",
+      transcriptsDataSourceId: "",
+      followupsDataSourceId: "",
+    };
+  }
+
   // If both data source IDs are already configured, offer to reuse the existing DBs.
   if (
     existing.transcriptsDataSourceId &&
@@ -699,9 +720,11 @@ async function step7_writeConfig(input: {
   // .dev.vars
   const devVarsLines = [
     `OPENAI_API_KEY="${input.openaiKey}"`,
-    `NOTION_INTEGRATION_KEY="${input.notionToken}"`,
     `BLUEDOT_WEBHOOK_SECRET="whsec_set_after_bluedot_config"`,
   ];
+  if (input.notionToken) {
+    devVarsLines.splice(1, 0, `NOTION_INTEGRATION_KEY="${input.notionToken}"`);
+  }
   if (input.mcp) {
     devVarsLines.push(
       `GITHUB_CLIENT_ID="${input.mcp.githubClientId}"`,
@@ -784,8 +807,10 @@ async function step9_syncSecretsToProd(input: {
 
   const targets: Array<{ name: string; value: string }> = [
     { name: "OPENAI_API_KEY", value: input.openaiKey },
-    { name: "NOTION_INTEGRATION_KEY", value: input.notionToken },
   ];
+  if (input.notionToken) {
+    targets.push({ name: "NOTION_INTEGRATION_KEY", value: input.notionToken });
+  }
   if (input.mcp) {
     targets.push(
       { name: "GITHUB_CLIENT_ID", value: input.mcp.githubClientId },
@@ -896,7 +921,9 @@ function printFinalSummary(args: {
     console.log("\x1b[1m2. Push any remaining prod secrets\x1b[0m");
     console.log("   You skipped some during setup. Run:");
     console.log("     \x1b[90mnpx wrangler secret put OPENAI_API_KEY\x1b[0m");
-    console.log("     \x1b[90mnpx wrangler secret put NOTION_INTEGRATION_KEY\x1b[0m");
+    if (notion.followupsDataSourceId) {
+      console.log("     \x1b[90mnpx wrangler secret put NOTION_INTEGRATION_KEY\x1b[0m");
+    }
     if (mcp) {
       console.log("     \x1b[90mnpx wrangler secret put GITHUB_CLIENT_ID\x1b[0m");
       console.log("     \x1b[90mnpx wrangler secret put GITHUB_CLIENT_SECRET\x1b[0m");

--- a/src/env.ts
+++ b/src/env.ts
@@ -13,15 +13,15 @@ export interface Env {
 
   // Secrets (wrangler secret put)
   OPENAI_API_KEY: string;
-  NOTION_INTEGRATION_KEY: string;
+  NOTION_INTEGRATION_KEY?: string;
   BLUEDOT_WEBHOOK_SECRET: string;
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
 
   // Vars (wrangler.toml)
   OPENAI_EXTRACTION_MODEL: string;
-  NOTION_TRANSCRIPTS_DATA_SOURCE_ID: string;
-  NOTION_FOLLOWUPS_DATA_SOURCE_ID: string;
+  NOTION_TRANSCRIPTS_DATA_SOURCE_ID?: string;
+  NOTION_FOLLOWUPS_DATA_SOURCE_ID?: string;
   ALLOWED_USERS: string;
   BASE_URL: string;
 

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -109,7 +109,7 @@ describe("handleWebhook — single event arrival", () => {
     expect(res.status).toBe(200);
 
     expect(env.VECTORIZE.upsert).toHaveBeenCalledOnce();
-    expect(deps.notion.pagesCreate).not.toHaveBeenCalled();
+    expect(deps.notion!.pagesCreate).not.toHaveBeenCalled();
     expect(deps.openai.chat.completions.create).not.toHaveBeenCalled(); // no extraction yet
 
     const row = await env.DB
@@ -127,7 +127,7 @@ describe("handleWebhook — single event arrival", () => {
     expect(res.status).toBe(200);
 
     expect(deps.openai.chat.completions.create).toHaveBeenCalledOnce();
-    expect(deps.notion.pagesCreate).not.toHaveBeenCalled(); // transcript not yet
+    expect(deps.notion!.pagesCreate).not.toHaveBeenCalled(); // transcript not yet
     expect(env.VECTORIZE.upsert).not.toHaveBeenCalled();
 
     const row = await env.DB
@@ -144,12 +144,12 @@ describe("handleWebhook — both events arrive", () => {
   it("transcript first then summary: triggers Notion writes on summary event", async () => {
     const deps1 = makeDeps();
     await handleWebhook(await signedRequest(transcriptPayload()), deps1);
-    expect(deps1.notion.pagesCreate).not.toHaveBeenCalled();
+    expect(deps1.notion!.pagesCreate).not.toHaveBeenCalled();
 
     const deps2 = makeDeps();
     await handleWebhook(await signedRequest(summaryPayload()), deps2);
     // 1 transcript page + 2 followups = 3 Notion calls
-    expect(deps2.notion.pagesCreate).toHaveBeenCalledTimes(3);
+    expect(deps2.notion!.pagesCreate).toHaveBeenCalledTimes(3);
 
     const row = await env.DB
       .prepare("SELECT notion_synced_at FROM transcripts WHERE video_id = ?")
@@ -161,11 +161,11 @@ describe("handleWebhook — both events arrive", () => {
   it("summary first then transcript: triggers Notion writes on transcript event", async () => {
     const deps1 = makeDeps();
     await handleWebhook(await signedRequest(summaryPayload()), deps1);
-    expect(deps1.notion.pagesCreate).not.toHaveBeenCalled();
+    expect(deps1.notion!.pagesCreate).not.toHaveBeenCalled();
 
     const deps2 = makeDeps();
     await handleWebhook(await signedRequest(transcriptPayload()), deps2);
-    expect(deps2.notion.pagesCreate).toHaveBeenCalledTimes(3);
+    expect(deps2.notion!.pagesCreate).toHaveBeenCalledTimes(3);
   });
 
   it("threads transcript page id into every Followup Meeting relation", async () => {
@@ -177,7 +177,7 @@ describe("handleWebhook — both events arrive", () => {
 
     // Call 0 is createTranscriptPage → mock returns { id: "page_1" }
     // Calls 1+ are createFollowupRow → should carry Meeting: { relation: [{ id: "page_1" }] }
-    const calls = (deps2.notion.pagesCreate as ReturnType<typeof vi.fn>).mock.calls;
+    const calls = (deps2.notion!.pagesCreate as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls.length).toBe(3);
     const followupBodies = calls.slice(1).map((c) => c[0] as { properties: Record<string, unknown> });
     for (const body of followupBodies) {
@@ -208,11 +208,11 @@ describe("handleWebhook — both events arrive", () => {
     await handleWebhook(await signedRequest(transcriptPayload()), deps1);
     const deps2 = makeDeps();
     await handleWebhook(await signedRequest(summaryPayload()), deps2);
-    expect(deps2.notion.pagesCreate).toHaveBeenCalledTimes(3);
+    expect(deps2.notion!.pagesCreate).toHaveBeenCalledTimes(3);
 
     const deps3 = makeDeps();
     await handleWebhook(await signedRequest(summaryPayload()), deps3);
-    expect(deps3.notion.pagesCreate).not.toHaveBeenCalled();
+    expect(deps3.notion!.pagesCreate).not.toHaveBeenCalled();
   });
 });
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -28,7 +28,7 @@ import type { ActionItem, Participant } from "./schema";
 
 export interface HandlerDeps {
   openai: OpenAI;
-  notion: NotionDeps;
+  notion: NotionDeps | null;
   env: Env;
 }
 
@@ -260,6 +260,13 @@ async function syncToNotion(
   transcriptId: number,
   videoId: string,
 ): Promise<void> {
+  const notion = deps.notion;
+  const transcriptsDataSourceId = deps.env.NOTION_TRANSCRIPTS_DATA_SOURCE_ID;
+  const followupsDataSourceId = deps.env.NOTION_FOLLOWUPS_DATA_SOURCE_ID;
+  if (!notion || !transcriptsDataSourceId || !followupsDataSourceId) {
+    log("info", "notion_sync_skipped_not_configured", { transcript_id: transcriptId, video_id: videoId });
+    return;
+  }
   const row = await deps.env.DB
     .prepare(
       `SELECT title, summary, participants, action_items, language, notion_synced_at, created_at
@@ -296,7 +303,7 @@ async function syncToNotion(
       { name: "bluedot.notion.create_transcript_page", op: "http.client" },
       () => createTranscriptPage(
         {
-          dataSourceId: deps.env.NOTION_TRANSCRIPTS_DATA_SOURCE_ID,
+          dataSourceId: transcriptsDataSourceId,
           title: row.title,
           summary: row.summary,
           participants,
@@ -305,7 +312,7 @@ async function syncToNotion(
           language: row.language,
           createdAt: new Date(row.created_at + "Z"),
         },
-        deps.notion,
+        notion,
       ),
     );
     pageId = page.pageId;
@@ -334,7 +341,7 @@ async function syncToNotion(
           { name: "bluedot.notion.create_followup", op: "http.client" },
           () => createFollowupRow(
             {
-              dataSourceId: deps.env.NOTION_FOLLOWUPS_DATA_SOURCE_ID,
+              dataSourceId: followupsDataSourceId,
               task: item.task,
               owner: item.owner,
               due_date: item.due_date,
@@ -343,7 +350,7 @@ async function syncToNotion(
               videoId,
               transcriptPageId: pageId,
             },
-            deps.notion,
+            notion,
           ),
         );
         followupsCreated++;
@@ -375,7 +382,7 @@ async function syncToNotion(
 export function buildHandlerDeps(env: Env): HandlerDeps {
   return {
     openai: new OpenAI({ apiKey: env.OPENAI_API_KEY }),
-    notion: createNotionDeps(env.NOTION_INTEGRATION_KEY),
+    notion: env.NOTION_INTEGRATION_KEY ? createNotionDeps(env.NOTION_INTEGRATION_KEY) : null,
     env,
   };
 }

--- a/src/mcp/tools/list_followups.ts
+++ b/src/mcp/tools/list_followups.ts
@@ -46,6 +46,16 @@ export async function listFollowups(
   env: Env,
   deps: ListFollowupsDeps = {},
 ): Promise<ToolResult> {
+  if (!env.NOTION_INTEGRATION_KEY || !env.NOTION_FOLLOWUPS_DATA_SOURCE_ID) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Notion is not configured for this deployment — the followups database is disabled.",
+        },
+      ],
+    };
+  }
   const fetchFn = deps.fetchFn ?? fetch;
   const limit = Math.max(1, Math.min(input.limit ?? 25, 100));
 


### PR DESCRIPTION
## Summary

- Adds a setup opt-out for Notion so aftercall can run as D1 + Vectorize only.
- Makes Notion env bindings optional and skips Notion sync when credentials or data source IDs are absent.
- Returns a clear MCP response from `list_followups` when the Followups database is disabled.
- Keeps the package lock root version aligned with `package.json`.

## Why

Forkers should be able to clone, configure, and deploy without needing a Notion account up front. D1 remains the source of truth, while Notion stays a derived optional view.

## Validation

- `npx vitest run`
- `npx tsc --noEmit`

## Notes

Draft PR for review before merge.