### PR TITLE
ci: deploy Worker from GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Denver
+    open-pull-requests-limit: 5
+    groups:
+      cloudflare:
+        patterns:
+          - "@cloudflare/*"
+          - "wrangler"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      mcp:
+        patterns:
+          - "@modelcontextprotocol/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: America/Denver
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,100 @@
-name: CI
+name: CI/CD
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  NODE_VERSION: 22
 
 jobs:
-  test:
+  validate:
+    name: Validate
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    timeout-minutes: 10
 
-      - uses: actions/setup-node@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
       - name: Typecheck
-        run: npx tsc --noEmit
+        run: npm run typecheck
 
       - name: Test
-        run: npx vitest run
+        run: npm test
+
+  deploy:
+    name: Deploy Cloudflare Worker
+    needs: validate
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: production
+      url: ${{ vars.BASE_URL }}
+    concurrency:
+      group: cloudflare-production
+      cancel-in-progress: false
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_WORKER_NAME: ${{ vars.CLOUDFLARE_WORKER_NAME }}
+      CLOUDFLARE_COMPATIBILITY_DATE: ${{ vars.CLOUDFLARE_COMPATIBILITY_DATE }}
+      CLOUDFLARE_D1_DATABASE_NAME: ${{ vars.CLOUDFLARE_D1_DATABASE_NAME }}
+      CLOUDFLARE_D1_DATABASE_ID: ${{ vars.CLOUDFLARE_D1_DATABASE_ID }}
+      CLOUDFLARE_VECTORIZE_INDEX_NAME: ${{ vars.CLOUDFLARE_VECTORIZE_INDEX_NAME }}
+      CLOUDFLARE_KV_NAMESPACE_ID: ${{ vars.CLOUDFLARE_KV_NAMESPACE_ID }}
+      OPENAI_EXTRACTION_MODEL: ${{ vars.OPENAI_EXTRACTION_MODEL }}
+      NOTION_TRANSCRIPTS_DATA_SOURCE_ID: ${{ vars.NOTION_TRANSCRIPTS_DATA_SOURCE_ID }}
+      NOTION_FOLLOWUPS_DATA_SOURCE_ID: ${{ vars.NOTION_FOLLOWUPS_DATA_SOURCE_ID }}
+      BASE_URL: ${{ vars.BASE_URL }}
+      ALLOWED_USERS: ${{ vars.ALLOWED_USERS }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ENVIRONMENT: ${{ vars.SENTRY_ENVIRONMENT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check Cloudflare deployment configuration
+        run: |
+          test -n "$CLOUDFLARE_API_TOKEN" || { echo "::error::Missing CLOUDFLARE_API_TOKEN secret"; exit 1; }
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || { echo "::error::Missing CLOUDFLARE_ACCOUNT_ID repository variable"; exit 1; }
+          npm run ci:wrangler-config
+
+      - name: Validate Worker bundle
+        run: npx wrangler deploy --dry-run --outdir dist --upload-source-maps
+
+      - name: Apply D1 migrations
+        run: npx wrangler d1 migrations apply "${CLOUDFLARE_D1_DATABASE_NAME:-aftercall-db}" --remote
+
+      - name: Deploy Worker
+        run: npm run deploy

--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ End-to-end MCP transport (`tools/list`, `tools/call` through Streamable HTTP) is
 
 ---
 
+## CI/CD
+
+GitHub Actions runs typecheck + tests on pull requests and deploys the
+Cloudflare Worker on pushes to `main`. The deploy job generates the gitignored
+`wrangler.toml` from repository variables, validates the Worker bundle, applies
+D1 migrations, and then runs `npm run deploy`.
+
+Setup details: [`docs/github-actions.md`](./docs/github-actions.md).
+
+---
+
 ## Operating
 
 | Task | Command |

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,81 @@
+# GitHub Actions CI/CD
+
+This repository deploys the Cloudflare Worker from GitHub Actions when changes
+land on `main`.
+
+## Workflows
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| `CI/CD` | Pull requests to `main` | Installs dependencies, typechecks, and runs tests |
+| `CI/CD` | Pushes to `main` or manual dispatch | Runs validation, generates `wrangler.toml`, dry-runs the Worker bundle, applies D1 migrations, and deploys |
+| `Dependabot` | Weekly | Opens grouped dependency PRs for npm and GitHub Actions |
+
+## Required Repository Secret
+
+Set this in GitHub under **Settings -> Secrets and variables -> Actions -> Secrets**:
+
+| Secret | Purpose |
+| --- | --- |
+| `CLOUDFLARE_API_TOKEN` | Authenticates Wrangler in CI. Use a Cloudflare API token scoped to the account that owns this Worker. |
+
+Cloudflare's Workers GitHub Actions docs recommend using a CI API token plus
+`CLOUDFLARE_ACCOUNT_ID` instead of interactive `wrangler login`.
+
+## Required Repository Variables
+
+Set these under **Settings -> Secrets and variables -> Actions -> Variables**:
+
+| Variable | Example | Purpose |
+| --- | --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | `9df...502d` | Cloudflare account that owns the Worker |
+| `CLOUDFLARE_WORKER_NAME` | `aftercall` | Worker script name |
+| `CLOUDFLARE_D1_DATABASE_NAME` | `aftercall-db` | D1 database name for migrations |
+| `CLOUDFLARE_D1_DATABASE_ID` | `2be...e1e` | D1 database ID for the `DB` binding |
+| `CLOUDFLARE_VECTORIZE_INDEX_NAME` | `aftercall-vectors` | Vectorize index name |
+| `CLOUDFLARE_KV_NAMESPACE_ID` | `60e...805` | KV namespace ID for OAuth state |
+| `BASE_URL` | `https://aftercall.example.workers.dev` | Public Worker origin used by OAuth callbacks |
+| `ALLOWED_USERS` | `palworth` | Comma-separated GitHub usernames allowed to use MCP |
+
+Optional variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CLOUDFLARE_COMPATIBILITY_DATE` | `2026-04-01` | Worker compatibility date |
+| `OPENAI_EXTRACTION_MODEL` | `gpt-5-mini` | Structured extraction model |
+| `NOTION_TRANSCRIPTS_DATA_SOURCE_ID` | empty | Notion transcripts data source |
+| `NOTION_FOLLOWUPS_DATA_SOURCE_ID` | empty | Notion followups data source |
+| `SENTRY_ENVIRONMENT` | `production` | Runtime Sentry environment var |
+
+Optional secret:
+
+| Secret | Purpose |
+| --- | --- |
+| `SENTRY_AUTH_TOKEN` | Enables source map upload during `npm run deploy` |
+
+## Worker Runtime Secrets
+
+GitHub Actions deploys the Worker code, but runtime secrets still live in
+Cloudflare. Set them with Wrangler:
+
+```bash
+npx wrangler secret put OPENAI_API_KEY
+npx wrangler secret put BLUEDOT_WEBHOOK_SECRET
+npx wrangler secret put GITHUB_CLIENT_ID
+npx wrangler secret put GITHUB_CLIENT_SECRET
+npx wrangler secret put NOTION_INTEGRATION_KEY
+npx wrangler secret put SENTRY_DSN
+```
+
+`NOTION_INTEGRATION_KEY` and `SENTRY_DSN` are only needed when those integrations
+are enabled.
+
+## Deployment Order
+
+On `main`, the deploy job:
+
+1. Generates `wrangler.toml` from repository variables.
+2. Runs `wrangler deploy --dry-run` to validate the bundle.
+3. Applies remote D1 migrations.
+4. Runs `npm run deploy`, which deploys the Worker and uploads Sentry source maps
+   when Sentry is configured.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "wrangler dev",
     "deploy": "node scripts/deploy.mjs",
     "notes:intake": "node scripts/obsidian-intake.ts",
+    "ci:wrangler-config": "node scripts/write-ci-wrangler-toml.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/scripts/write-ci-wrangler-toml.mjs
+++ b/scripts/write-ci-wrangler-toml.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Generate wrangler.toml in CI from GitHub repository variables.
+ *
+ * The real wrangler.toml is intentionally gitignored because it contains
+ * workspace-specific Cloudflare resource IDs. GitHub Actions can recreate it
+ * just before validation/deploy without committing those IDs.
+ */
+import { writeFileSync } from "node:fs";
+
+const required = [
+  "CLOUDFLARE_D1_DATABASE_ID",
+  "CLOUDFLARE_KV_NAMESPACE_ID",
+  "BASE_URL",
+  "ALLOWED_USERS",
+];
+
+const missing = required.filter((name) => !process.env[name]);
+if (missing.length > 0) {
+  for (const name of missing) {
+    console.error(`::error::Missing required environment variable ${name}`);
+  }
+  process.exit(1);
+}
+
+const config = {
+  workerName: env("CLOUDFLARE_WORKER_NAME", "aftercall"),
+  compatibilityDate: env("CLOUDFLARE_COMPATIBILITY_DATE", "2026-04-01"),
+  openaiExtractionModel: env("OPENAI_EXTRACTION_MODEL", "gpt-5-mini"),
+  notionTranscriptsDataSourceId: env("NOTION_TRANSCRIPTS_DATA_SOURCE_ID", ""),
+  notionFollowupsDataSourceId: env("NOTION_FOLLOWUPS_DATA_SOURCE_ID", ""),
+  baseUrl: requiredEnv("BASE_URL"),
+  allowedUsers: requiredEnv("ALLOWED_USERS"),
+  sentryEnvironment: env("SENTRY_ENVIRONMENT", "production"),
+  d1DatabaseName: env("CLOUDFLARE_D1_DATABASE_NAME", "aftercall-db"),
+  d1DatabaseId: requiredEnv("CLOUDFLARE_D1_DATABASE_ID"),
+  vectorizeIndexName: env("CLOUDFLARE_VECTORIZE_INDEX_NAME", "aftercall-vectors"),
+  kvNamespaceId: requiredEnv("CLOUDFLARE_KV_NAMESPACE_ID"),
+};
+
+const toml = `name = ${tomlString(config.workerName)}
+main = "src/index.ts"
+compatibility_date = ${tomlString(config.compatibilityDate)}
+compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
+
+[vars]
+OPENAI_EXTRACTION_MODEL = ${tomlString(config.openaiExtractionModel)}
+NOTION_TRANSCRIPTS_DATA_SOURCE_ID = ${tomlString(config.notionTranscriptsDataSourceId)}
+NOTION_FOLLOWUPS_DATA_SOURCE_ID = ${tomlString(config.notionFollowupsDataSourceId)}
+BASE_URL = ${tomlString(config.baseUrl)}
+ALLOWED_USERS = ${tomlString(config.allowedUsers)}
+SENTRY_ENVIRONMENT = ${tomlString(config.sentryEnvironment)}
+
+[[d1_databases]]
+binding = "DB"
+database_name = ${tomlString(config.d1DatabaseName)}
+database_id = ${tomlString(config.d1DatabaseId)}
+migrations_dir = "drizzle"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = ${tomlString(config.vectorizeIndexName)}
+remote = true
+
+[[kv_namespaces]]
+binding = "OAUTH_KV"
+id = ${tomlString(config.kvNamespaceId)}
+
+[observability]
+enabled = true
+`;
+
+writeFileSync("wrangler.toml", toml, "utf8");
+console.log(`Generated wrangler.toml for Worker ${config.workerName}`);
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+function env(name, fallback) {
+  const value = process.env[name];
+  return value == null || value === "" ? fallback : value;
+}
+
+function tomlString(value) {
+  return JSON.stringify(value);
+}


### PR DESCRIPTION
## Summary

- Upgrades the existing CI workflow into a CI/CD workflow.
- Runs install, typecheck, and tests on PRs and pushes to `main`.
- Deploys the Cloudflare Worker after successful validation on pushes to `main` or manual dispatch.
- Generates the gitignored `wrangler.toml` from GitHub repository variables in CI.
- Validates the Worker bundle with `wrangler deploy --dry-run`, applies remote D1 migrations, then runs `npm run deploy`.
- Adds weekly Dependabot updates for npm and GitHub Actions.
- Documents the required GitHub Actions variables/secrets.

## Cloudflare/GitHub setup done

I set the non-secret repository variables in `palworth/deborah` from the local Cloudflare config: account ID, Worker name, D1 database, Vectorize index, KV namespace, base URL, allowed user, extraction model, and Sentry environment.

## Remaining secret

GitHub still needs the `CLOUDFLARE_API_TOKEN` Actions secret before the deploy job can succeed. The workflow explicitly checks for it and fails with a clear error if it is missing.

## Validation

- YAML parsed for `.github/workflows/ci.yml` and `.github/dependabot.yml`
- Smoke-tested `scripts/write-ci-wrangler-toml.mjs` in a temp directory
- `git diff --check`
- `npx tsc --noEmit`
- `npx vitest run`
- `npx wrangler deploy --dry-run --outdir dist --upload-source-maps`

## References

Cloudflare Workers GitHub Actions docs require a CI API token and account ID for non-interactive Wrangler deploys.