### PR TITLE
feat: add Obsidian note inbox sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ Details: [`docs/obsidian-backup.md`](./docs/obsidian-backup.md).
 
 ---
 
+## Obsidian note inbox sync
+
+Deborah can queue dictated thoughts and project updates from MCP clients, then a
+local sync command writes them into the Obsidian vault.
+
+```bash
+export DEBORAH_WORKER_URL="https://aftercall.pierce-9df.workers.dev"
+npm run notes:sync
+```
+
+Details: [`docs/note-inbox-sync.md`](./docs/note-inbox-sync.md).
+
+---
+
 ## Architecture
 
 Three flows compose the system. Each has its own diagram and runbook:

--- a/conductor/tracks/note-inbox-sync/spec.md
+++ b/conductor/tracks/note-inbox-sync/spec.md
@@ -1,0 +1,32 @@
+# Note Inbox Sync
+
+## Intent
+
+Let Pierce dump thoughts from Codex, ChatGPT, or future inputs like Slack, then
+land those thoughts in the local Obsidian vault with minimal manual handling.
+
+## V1 Scope
+
+- Add a D1-backed note inbox.
+- Add an MCP tool, `capture_thought`, that queues structured Obsidian intake
+  plans.
+- Add local bearer-protected endpoints for a sync agent:
+  - `GET /notes/pending`
+  - `POST /notes/:id/synced`
+  - `POST /notes/capture`
+- Add `npm run notes:sync` to write pending items into the local vault and ack
+  them only after successful local writes.
+
+## Non-Goals
+
+- No local daemon yet.
+- No automatic OpenAI organization inside the Worker yet; the MCP caller can
+  pass structured fields.
+- No Slack ingestion yet.
+- No direct cloud write access to the local vault.
+
+## Decision
+
+Use Cloudflare as the durable queue and context layer, and keep Obsidian file
+writes local. This keeps the workflow accessible from remote MCP clients while
+preserving the local-vault safety boundary.

--- a/docs/note-inbox-sync.md
+++ b/docs/note-inbox-sync.md
@@ -1,0 +1,62 @@
+# Note Inbox Sync
+
+Deborah can now act as a cloud inbox for thoughts that should land in a local
+Obsidian vault.
+
+## Workflow
+
+1. An MCP client calls `capture_thought`.
+2. Deborah stores the structured intake plan in D1 as `pending`.
+3. A local command pulls pending notes.
+4. The local command writes Markdown into the Obsidian vault.
+5. Only after local writes succeed, the command marks the item `synced`.
+
+This keeps Obsidian local while still letting Codex, ChatGPT, and future inputs
+like Slack use the same capture surface.
+
+## MCP Tool
+
+`capture_thought` accepts:
+
+- `dump` — raw text to preserve.
+- `title` — optional short title.
+- `summary` — optional organized summary.
+- `tags`, `projects`, `people`, `tasks`, `decisions` — optional structured
+  Obsidian intake fields.
+
+The tool does not write local files directly. It queues work for the local sync
+agent.
+
+## Local Sync
+
+```bash
+export DEBORAH_WORKER_URL="https://aftercall.pierce-9df.workers.dev"
+npm run notes:sync
+```
+
+The command auto-detects the open Obsidian vault on macOS. You can also pass it
+explicitly:
+
+```bash
+npm run notes:sync -- --vault "/Users/pierce/Documents/Pierce's workspace"
+```
+
+It uses the same local bearer as vault backup:
+
+- `VAULT_SYNC_TOKEN`
+- `VAULT_SYNC_SECRET`
+- `~/.deborah/vault-sync-token`
+
+## API Endpoints
+
+These endpoints are for the local sync agent and require the local bearer:
+
+- `POST /notes/capture`
+- `GET /notes/pending?limit=25`
+- `POST /notes/:id/synced`
+
+## Why Hybrid
+
+Cloudflare is the queue and context layer. The local script is the filesystem
+writer. That means captured notes work from Codex or ChatGPT, but nothing in the
+cloud needs direct access to the Mac's local vault.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -4,6 +4,26 @@ Six tools are exposed at `/mcp`. Every tool returns a single `text` content bloc
 
 All tools require a valid bearer token (minted via the GitHub OAuth flow — see [auth.md](./auth.md)).
 
+## `capture_thought`
+
+Queue a raw thought dump, project update, task list, or decision for local
+Obsidian sync. Deborah stores the capture in D1; `npm run notes:sync` writes it
+to the local vault later.
+
+Required:
+
+- `dump` — raw text to preserve.
+
+Optional:
+
+- `title`
+- `summary`
+- `tags`
+- `projects`
+- `people`
+- `tasks`
+- `decisions`
+
 ---
 
 ## `search_calls`

--- a/drizzle/0003_note_inbox.sql
+++ b/drizzle/0003_note_inbox.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `note_inbox` (
+  `id` text PRIMARY KEY NOT NULL,
+  `source` text NOT NULL DEFAULT 'mcp',
+  `title` text,
+  `dump` text NOT NULL,
+  `intake_plan` text NOT NULL,
+  `status` text NOT NULL DEFAULT 'pending',
+  `error` text,
+  `created_at` text NOT NULL DEFAULT (datetime('now')),
+  `synced_at` text,
+  `sync_device` text,
+  `obsidian_paths` text NOT NULL DEFAULT '[]'
+);
+--> statement-breakpoint
+CREATE INDEX `note_inbox_status_created_at_idx`
+ON `note_inbox` (`status`, `created_at`);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "wrangler dev",
     "deploy": "node scripts/deploy.mjs",
     "notes:intake": "node scripts/obsidian-intake.ts",
+    "notes:sync": "node scripts/notes-sync.ts",
     "vault:backup": "node scripts/obsidian-backup.ts",
     "ci:wrangler-config": "node scripts/write-ci-wrangler-toml.mjs",
     "test": "vitest run",

--- a/scripts/notes-sync.ts
+++ b/scripts/notes-sync.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Pull Deborah note inbox items from Cloudflare and write them into a local
+ * Obsidian vault. Cloudflare is the queue; this script is the local filesystem
+ * hand that can safely touch the vault.
+ */
+import { constants } from "node:fs";
+import { access, appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { parseArgs } from "node:util";
+import { buildIntakeDocuments, type IntakeDocument, type IntakePlan } from "../src/obsidian/intake.ts";
+import { syncNoteInboxToObsidian } from "../src/notes/local-sync.ts";
+
+interface WriteResult {
+  paths: string[];
+}
+
+const { values } = parseArgs({
+  options: {
+    url: { type: "string" },
+    vault: { type: "string" },
+    token: { type: "string" },
+    limit: { type: "string" },
+    device: { type: "string" },
+  },
+});
+
+async function main(): Promise<void> {
+  const baseUrl = values.url ?? process.env.DEBORAH_WORKER_URL ?? process.env.BASE_URL;
+  if (!baseUrl) fail("Set --url, DEBORAH_WORKER_URL, or BASE_URL.");
+
+  const token =
+    values.token ??
+    process.env.VAULT_SYNC_TOKEN ??
+    process.env.VAULT_SYNC_SECRET ??
+    (await readTokenFile());
+  if (!token) fail("Set --token, VAULT_SYNC_TOKEN, or VAULT_SYNC_SECRET.");
+
+  const vaultPath = values.vault ?? process.env.OBSIDIAN_VAULT ?? (await detectObsidianVault());
+  if (!vaultPath) fail("Set --vault or OBSIDIAN_VAULT to your local Obsidian vault path.");
+
+  const vault = resolve(expandHome(vaultPath));
+  await ensureDirectory(vault, "Obsidian vault");
+
+  const result = await syncNoteInboxToObsidian({
+    baseUrl,
+    token,
+    limit: values.limit ? Number(values.limit) : undefined,
+    device: values.device ?? hostname(),
+    writePlan: (plan, options) => writePlanToVault(vault, plan, options),
+  });
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function writePlanToVault(
+  vault: string,
+  plan: IntakePlan,
+  options: { now?: Date },
+): Promise<WriteResult> {
+  const docs = buildIntakeDocuments(plan, { now: options.now });
+  const paths: string[] = [];
+  for (const doc of docs) {
+    await writeDocument(vault, doc);
+    paths.push(doc.path);
+  }
+  return { paths };
+}
+
+async function writeDocument(vault: string, doc: IntakeDocument): Promise<void> {
+  const target = resolveInsideVault(vault, doc.path);
+  await mkdir(dirname(target), { recursive: true });
+
+  if (doc.mode === "create") {
+    if (await exists(target)) return;
+    await writeFile(target, ensureTrailingNewline(doc.createContent), "utf8");
+    return;
+  }
+
+  if (await exists(target)) {
+    await appendFile(target, ensureLeadingNewline(doc.appendContent ?? ""), "utf8");
+    return;
+  }
+
+  await writeFile(target, ensureTrailingNewline(doc.createContent), "utf8");
+}
+
+async function ensureDirectory(path: string, label: string): Promise<void> {
+  try {
+    await access(path, constants.R_OK | constants.W_OK);
+  } catch {
+    fail(`${label} does not exist or is not writable: ${path}`);
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveInsideVault(vault: string, relativePath: string): string {
+  if (isAbsolute(relativePath)) fail(`Document paths must be vault-relative: ${relativePath}`);
+  const target = resolve(vault, relativePath);
+  if (target !== vault && !target.startsWith(`${vault}${sep}`)) {
+    fail(`Document path escapes the vault: ${relativePath}`);
+  }
+  return target;
+}
+
+function expandHome(path: string): string {
+  if (path === "~") return process.env.HOME ?? path;
+  if (path.startsWith("~/")) return join(process.env.HOME ?? "", path.slice(2));
+  return path;
+}
+
+async function detectObsidianVault(): Promise<string | undefined> {
+  const configPath = join(process.env.HOME ?? "", "Library", "Application Support", "obsidian", "obsidian.json");
+  try {
+    const raw = await readFile(configPath, "utf8");
+    const config = JSON.parse(raw) as {
+      vaults?: Record<string, { path?: string; ts?: number; open?: boolean }>;
+    };
+    const vaults = Object.values(config.vaults ?? {})
+      .filter((vault): vault is { path: string; ts?: number; open?: boolean } => Boolean(vault.path))
+      .sort((a, b) => {
+        if (a.open !== b.open) return a.open ? -1 : 1;
+        return (b.ts ?? 0) - (a.ts ?? 0);
+      });
+    return vaults[0]?.path;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readTokenFile(): Promise<string | undefined> {
+  try {
+    return (await readFile(join(process.env.HOME ?? "", ".deborah", "vault-sync-token"), "utf8")).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function ensureLeadingNewline(content: string): string {
+  const withTrailing = ensureTrailingNewline(content);
+  return withTrailing.startsWith("\n") ? withTrailing : `\n${withTrailing}`;
+}
+
+function ensureTrailingNewline(content: string): string {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -17,6 +17,11 @@ import { createGitHubAuthApp } from "./auth/github";
 import { mcpApiHandler } from "./handler";
 import { handleWebhook, buildHandlerDeps } from "../handler";
 import { handleVaultSync } from "../obsidian/backup";
+import {
+  handleCaptureThought,
+  handleListPendingNotes,
+  handleMarkNoteSynced,
+} from "../notes/inbox";
 
 type Bindings = Env & { OAUTH_PROVIDER: OAuthHelpers };
 
@@ -48,6 +53,9 @@ function createDefaultApp() {
   // Local Obsidian vault backup endpoint. Authenticated separately from MCP
   // because the local sync script is not an OAuth client.
   app.post("/vault/sync", (c) => handleVaultSync(c.req.raw, c.env));
+  app.post("/notes/capture", (c) => handleCaptureThought(c.req.raw, c.env));
+  app.get("/notes/pending", (c) => handleListPendingNotes(c.req.raw, c.env));
+  app.post("/notes/:id/synced", (c) => handleMarkNoteSynced(c.req.raw, c.env));
 
   // Fallback: Bluedot webhook on POST. Preserves the pre-MCP behavior where
   // Bluedot hits the worker root with a signed payload.

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -16,6 +16,7 @@ import { listFollowups } from "./tools/list_followups";
 import { findActionItemsFor } from "./tools/find_action_items_for";
 import { recentCalls } from "./tools/recent_calls";
 import { answerFromTranscript } from "./tools/answer_from_transcript";
+import { captureThought } from "../notes/inbox";
 
 export function createMcpServer(env: Env): McpServer {
   const server = new McpServer(
@@ -118,6 +119,69 @@ export function createMcpServer(env: Env): McpServer {
       },
     },
     async (args) => (await answerFromTranscript(args, env)) as any,
+  );
+
+  server.registerTool(
+    "capture_thought",
+    {
+      title: "Capture thought for Obsidian",
+      description:
+        "Capture a user brain dump, project update, task, or decision into Deborah's note inbox. The local sync agent will later write it into the user's Obsidian vault as Markdown.",
+      inputSchema: {
+        title: z.string().optional().describe("Short title for the captured dump."),
+        dump: z.string().min(1).describe("The raw thought dump to preserve and sync to Obsidian."),
+        summary: z.string().optional().describe("One or two sentence organized summary."),
+        tags: z.array(z.string()).optional().describe("Obsidian-friendly tags without #."),
+        projects: z
+          .array(
+            z.object({
+              name: z.string().min(1),
+              status: z.enum(["active", "paused", "waiting", "done"]).optional(),
+              summary: z.string().optional(),
+              notes: z.array(z.string()).optional(),
+              nextActions: z.array(z.string()).optional(),
+            }),
+          )
+          .optional()
+          .describe("Project notes or updates inferred from the dump."),
+        people: z
+          .array(
+            z.object({
+              name: z.string().min(1),
+              summary: z.string().optional(),
+              notes: z.array(z.string()).optional(),
+              nextActions: z.array(z.string()).optional(),
+            }),
+          )
+          .optional()
+          .describe("People notes or follow-ups inferred from the dump."),
+        tasks: z
+          .array(
+            z.object({
+              text: z.string().min(1),
+              project: z.string().optional(),
+              person: z.string().optional(),
+              due: z.string().optional(),
+              priority: z.enum(["low", "medium", "high"]).optional(),
+              status: z.enum(["todo", "doing", "done"]).optional(),
+            }),
+          )
+          .optional()
+          .describe("Concrete next actions from the dump."),
+        decisions: z
+          .array(
+            z.object({
+              title: z.string().min(1),
+              project: z.string().optional(),
+              decision: z.string().min(1),
+              rationale: z.string().optional(),
+            }),
+          )
+          .optional()
+          .describe("Decisions to create as Obsidian decision notes."),
+      },
+    },
+    async (args) => (await captureThought(args, env)) as any,
   );
 
   server.registerTool(

--- a/src/notes/inbox.test.ts
+++ b/src/notes/inbox.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { setupD1 } from "../../test/setup-d1";
+import {
+  captureThought,
+  handleListPendingNotes,
+  handleMarkNoteSynced,
+} from "./inbox";
+
+beforeEach(async () => {
+  await setupD1();
+});
+
+function authedRequest(url: string, init: RequestInit = {}): Request {
+  return new Request(url, {
+    ...init,
+    headers: {
+      authorization: "Bearer vault-sync-test-token",
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+describe("note inbox", () => {
+  it("captures a structured thought as a pending Obsidian intake plan", async () => {
+    const result = await captureThought(
+      {
+        title: "Deborah sync workflow",
+        dump: "Need a local sync agent that writes organized notes into Obsidian.",
+        summary: "Hybrid Cloudflare plus local Obsidian sync is the preferred workflow.",
+        tags: ["deborah", "workflow"],
+        projects: [
+          {
+            name: "Deborah",
+            status: "active",
+            nextActions: ["Build notes inbox sync"],
+          },
+        ],
+        tasks: [
+          {
+            text: "Build notes inbox sync",
+            project: "Deborah",
+            priority: "high",
+          },
+        ],
+      },
+      env,
+      { id: () => "note_test_1", now: () => "2026-04-28 05:00:00" },
+    );
+
+    expect(result.content[0].text).toContain("Captured thought");
+    expect(result.content[0].text).toContain("note_test_1");
+
+    const row = await env.DB
+      .prepare("SELECT id, status, source, title, intake_plan FROM note_inbox WHERE id = ?1")
+      .bind("note_test_1")
+      .first<{
+        id: string;
+        status: string;
+        source: string;
+        title: string;
+        intake_plan: string;
+      }>();
+
+    expect(row).toMatchObject({
+      id: "note_test_1",
+      status: "pending",
+      source: "mcp",
+      title: "Deborah sync workflow",
+    });
+    expect(JSON.parse(row!.intake_plan)).toMatchObject({
+      title: "Deborah sync workflow",
+      dump: "Need a local sync agent that writes organized notes into Obsidian.",
+      projects: [{ name: "Deborah" }],
+    });
+  });
+
+  it("lists pending notes for the local Obsidian sync agent", async () => {
+    await captureThought({ title: "First", dump: "one" }, env, {
+      id: () => "note_1",
+      now: () => "2026-04-28 05:00:00",
+    });
+    await captureThought({ title: "Second", dump: "two" }, env, {
+      id: () => "note_2",
+      now: () => "2026-04-28 05:01:00",
+    });
+
+    const res = await handleListPendingNotes(
+      authedRequest("https://aftercall.test/notes/pending?limit=1"),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      notes: [
+        {
+          id: "note_1",
+          status: "pending",
+          intakePlan: { title: "First", dump: "one" },
+        },
+      ],
+    });
+  });
+
+  it("marks a pending note as synced after local Obsidian writes succeed", async () => {
+    await captureThought({ title: "Done", dump: "synced" }, env, {
+      id: () => "note_done",
+      now: () => "2026-04-28 05:00:00",
+    });
+
+    const res = await handleMarkNoteSynced(
+      authedRequest("https://aftercall.test/notes/note_done/synced", {
+        method: "POST",
+        body: JSON.stringify({
+          device: "pierce-mbp",
+          paths: ["Inbox/2026-04-28.md", "Projects/Deborah.md"],
+        }),
+      }),
+      env,
+      { now: () => "2026-04-28 05:05:00" },
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, id: "note_done" });
+
+    const row = await env.DB
+      .prepare("SELECT status, sync_device, obsidian_paths, synced_at FROM note_inbox WHERE id = ?1")
+      .bind("note_done")
+      .first<{
+        status: string;
+        sync_device: string;
+        obsidian_paths: string;
+        synced_at: string;
+      }>();
+
+    expect(row).toEqual({
+      status: "synced",
+      sync_device: "pierce-mbp",
+      obsidian_paths: JSON.stringify(["Inbox/2026-04-28.md", "Projects/Deborah.md"]),
+      synced_at: "2026-04-28 05:05:00",
+    });
+  });
+
+  it("rejects local sync requests without the bearer secret", async () => {
+    const res = await handleListPendingNotes(
+      new Request("https://aftercall.test/notes/pending"),
+      env,
+    );
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Unauthorized");
+  });
+});

--- a/src/notes/inbox.ts
+++ b/src/notes/inbox.ts
@@ -1,0 +1,199 @@
+import type { Env } from "../env";
+import type {
+  IntakeDecision,
+  IntakePerson,
+  IntakePlan,
+  IntakeProject,
+  IntakeTask,
+} from "../obsidian/intake";
+import type { ToolResult } from "../mcp/tools/recent_calls";
+
+export interface CaptureThoughtInput {
+  title?: string;
+  dump: string;
+  summary?: string;
+  tags?: string[];
+  projects?: IntakeProject[];
+  people?: IntakePerson[];
+  tasks?: IntakeTask[];
+  decisions?: IntakeDecision[];
+}
+
+interface CaptureDeps {
+  id?: () => string;
+  now?: () => string;
+}
+
+interface PendingNoteRow {
+  id: string;
+  source: string;
+  title: string | null;
+  status: string;
+  created_at: string;
+  intake_plan: string;
+}
+
+const MAX_DUMP_CHARS = 25_000;
+const MAX_PENDING_LIMIT = 50;
+
+export async function captureThought(
+  input: CaptureThoughtInput,
+  env: Env,
+  deps: CaptureDeps = {},
+): Promise<ToolResult> {
+  const plan = normalizeCaptureInput(input);
+  const id = deps.id?.() ?? crypto.randomUUID();
+  const createdAt = deps.now?.() ?? sqliteNow();
+
+  await env.DB
+    .prepare(
+      `INSERT INTO note_inbox
+         (id, source, title, dump, intake_plan, status, created_at, obsidian_paths)
+       VALUES (?1, 'mcp', ?2, ?3, ?4, 'pending', ?5, '[]')`,
+    )
+    .bind(id, plan.title ?? null, plan.dump, JSON.stringify(plan), createdAt)
+    .run();
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Captured thought ${id}. It is queued for local Obsidian sync.`,
+      },
+    ],
+  };
+}
+
+export async function handleCaptureThought(request: Request, env: Env): Promise<Response> {
+  const unauthorized = requireLocalBearer(request, env);
+  if (unauthorized) return unauthorized;
+
+  let input: CaptureThoughtInput;
+  try {
+    input = await request.json();
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  try {
+    const result = await captureThought(input, env);
+    return Response.json({
+      ok: true,
+      message: result.content[0].text,
+    });
+  } catch (error) {
+    return new Response(error instanceof Error ? error.message : String(error), { status: 400 });
+  }
+}
+
+export async function handleListPendingNotes(request: Request, env: Env): Promise<Response> {
+  const unauthorized = requireLocalBearer(request, env);
+  if (unauthorized) return unauthorized;
+
+  const url = new URL(request.url);
+  const limit = clampLimit(Number(url.searchParams.get("limit") ?? 25));
+  const { results } = await env.DB
+    .prepare(
+      `SELECT id, source, title, status, created_at, intake_plan
+       FROM note_inbox
+       WHERE status = 'pending'
+       ORDER BY created_at ASC
+       LIMIT ?1`,
+    )
+    .bind(limit)
+    .all<PendingNoteRow>();
+
+  return Response.json({
+    notes: (results ?? []).map((row) => ({
+      id: row.id,
+      source: row.source,
+      title: row.title,
+      status: row.status,
+      createdAt: row.created_at,
+      intakePlan: JSON.parse(row.intake_plan) as IntakePlan,
+    })),
+  });
+}
+
+export async function handleMarkNoteSynced(
+  request: Request,
+  env: Env,
+  deps: Pick<CaptureDeps, "now"> = {},
+): Promise<Response> {
+  const unauthorized = requireLocalBearer(request, env);
+  if (unauthorized) return unauthorized;
+
+  const id = noteIdFromSyncedUrl(request.url);
+  if (!id) return new Response("Missing note id", { status: 400 });
+
+  let body: { device?: string; paths?: string[] };
+  try {
+    body = await request.json();
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const paths = Array.isArray(body.paths) ? body.paths.filter((path) => typeof path === "string") : [];
+  const syncedAt = deps.now?.() ?? sqliteNow();
+  await env.DB
+    .prepare(
+      `UPDATE note_inbox
+       SET status = 'synced',
+           synced_at = ?1,
+           sync_device = ?2,
+           obsidian_paths = ?3
+       WHERE id = ?4 AND status = 'pending'`,
+    )
+    .bind(syncedAt, body.device ?? null, JSON.stringify(paths), id)
+    .run();
+
+  return Response.json({ ok: true, id });
+}
+
+function normalizeCaptureInput(input: CaptureThoughtInput): IntakePlan {
+  const dump = input.dump?.trim();
+  if (!dump) throw new Error("dump is required");
+  if (dump.length > MAX_DUMP_CHARS) {
+    throw new Error(`dump is too long; max ${MAX_DUMP_CHARS} characters`);
+  }
+
+  return {
+    title: cleanOptional(input.title),
+    dump,
+    summary: cleanOptional(input.summary),
+    tags: input.tags?.filter((tag) => typeof tag === "string" && tag.trim()),
+    projects: input.projects,
+    people: input.people,
+    tasks: input.tasks,
+    decisions: input.decisions,
+  };
+}
+
+function requireLocalBearer(request: Request, env: Env): Response | null {
+  const auth = request.headers.get("authorization") ?? "";
+  const token = auth.replace(/^Bearer\s+/i, "").trim();
+  if (!env.VAULT_SYNC_SECRET || !token || token !== env.VAULT_SYNC_SECRET) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  return null;
+}
+
+function noteIdFromSyncedUrl(url: string): string | null {
+  const pathname = new URL(url).pathname;
+  const match = pathname.match(/^\/notes\/([^/]+)\/synced$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+function clampLimit(value: number): number {
+  if (!Number.isFinite(value)) return 25;
+  return Math.max(1, Math.min(Math.trunc(value), MAX_PENDING_LIMIT));
+}
+
+function cleanOptional(value: string | undefined): string | undefined {
+  const cleaned = value?.trim();
+  return cleaned || undefined;
+}
+
+function sqliteNow(): string {
+  return new Date().toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
+}

--- a/src/notes/local-sync.test.ts
+++ b/src/notes/local-sync.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { syncNoteInboxToObsidian } from "./local-sync";
+
+describe("syncNoteInboxToObsidian", () => {
+  it("pulls pending note inbox items, writes Obsidian documents, then acks them", async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith("/notes/pending?limit=25")) {
+        return Response.json({
+          notes: [
+            {
+              id: "note_1",
+              intakePlan: {
+                title: "Voice dump",
+                dump: "I need Deborah to organize dictated notes.",
+                tasks: [{ text: "Design note sync workflow", project: "Deborah" }],
+              },
+            },
+          ],
+        });
+      }
+      if (href.endsWith("/notes/note_1/synced") && init?.method === "POST") {
+        return Response.json({ ok: true, id: "note_1" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    const writePlan = vi.fn(async () => ({
+      paths: ["Inbox/2026-04-28.md", "Next Actions.md"],
+    }));
+
+    const result = await syncNoteInboxToObsidian({
+      baseUrl: "https://aftercall.test",
+      token: "secret",
+      fetch: fetchMock,
+      writePlan,
+      now: new Date(2026, 3, 28, 9, 30, 0),
+      device: "test-device",
+    });
+
+    expect(result.synced).toBe(1);
+    expect(result.notes[0].id).toBe("note_1");
+    expect(result.notes[0].paths).toEqual(
+      expect.arrayContaining(["Inbox/2026-04-28.md", "Next Actions.md"]),
+    );
+
+    expect(writePlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Voice dump",
+        dump: "I need Deborah to organize dictated notes.",
+      }),
+      { now: new Date(2026, 3, 28, 9, 30, 0) },
+    );
+
+    const ackBody = JSON.parse(String(fetchMock.mock.calls[1][1]?.body));
+    expect(ackBody).toMatchObject({
+      device: "test-device",
+      paths: expect.arrayContaining(["Inbox/2026-04-28.md", "Next Actions.md"]),
+    });
+  });
+});

--- a/src/notes/local-sync.ts
+++ b/src/notes/local-sync.ts
@@ -1,0 +1,68 @@
+import type { IntakePlan } from "../obsidian/intake";
+
+interface PendingNote {
+  id: string;
+  intakePlan: IntakePlan;
+}
+
+interface PendingResponse {
+  notes?: PendingNote[];
+}
+
+export interface WritePlanResult {
+  paths: string[];
+}
+
+export interface SyncNoteInboxOptions {
+  baseUrl: string;
+  token: string;
+  fetch?: typeof fetch;
+  writePlan: (plan: IntakePlan, options: { now?: Date }) => Promise<WritePlanResult>;
+  limit?: number;
+  now?: Date;
+  device?: string;
+}
+
+export interface SyncNoteInboxResult {
+  synced: number;
+  notes: Array<{ id: string; paths: string[] }>;
+}
+
+export async function syncNoteInboxToObsidian(
+  options: SyncNoteInboxOptions,
+): Promise<SyncNoteInboxResult> {
+  const fetchImpl = options.fetch ?? fetch;
+  const baseUrl = options.baseUrl.replace(/\/+$/, "");
+  const limit = options.limit ?? 25;
+  const pendingRes = await fetchImpl(`${baseUrl}/notes/pending?limit=${limit}`, {
+    headers: { authorization: `Bearer ${options.token}` },
+  });
+  if (!pendingRes.ok) {
+    throw new Error(`Failed to list pending notes: ${pendingRes.status} ${await pendingRes.text()}`);
+  }
+
+  const pending = (await pendingRes.json()) as PendingResponse;
+  const notes = pending.notes ?? [];
+  const synced: SyncNoteInboxResult["notes"] = [];
+
+  for (const note of notes) {
+    const write = await options.writePlan(note.intakePlan, { now: options.now });
+    const ackRes = await fetchImpl(`${baseUrl}/notes/${encodeURIComponent(note.id)}/synced`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        device: options.device,
+        paths: write.paths,
+      }),
+    });
+    if (!ackRes.ok) {
+      throw new Error(`Failed to mark note ${note.id} synced: ${ackRes.status} ${await ackRes.text()}`);
+    }
+    synced.push({ id: note.id, paths: write.paths });
+  }
+
+  return { synced: synced.length, notes: synced };
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -87,5 +87,24 @@ export const vaultFiles = sqliteTable("vault_files", {
   pk: primaryKey({ columns: [table.vaultName, table.path] }),
 }));
 
+export const noteInbox = sqliteTable("note_inbox", {
+  id: text("id").primaryKey(),
+  source: text("source").notNull().default("mcp"),
+  title: text("title"),
+  dump: text("dump").notNull(),
+  intakePlan: text("intake_plan", { mode: "json" }).notNull(),
+  status: text("status").notNull().default("pending"),
+  error: text("error"),
+  createdAt: text("created_at")
+    .notNull()
+    .default(sql`(datetime('now'))`),
+  syncedAt: text("synced_at"),
+  syncDevice: text("sync_device"),
+  obsidianPaths: text("obsidian_paths", { mode: "json" })
+    .$type<string[]>()
+    .notNull()
+    .default(sql`'[]'`),
+});
+
 export type Transcript = typeof transcripts.$inferSelect;
 export type NewTranscript = typeof transcripts.$inferInsert;

--- a/test/setup-d1.ts
+++ b/test/setup-d1.ts
@@ -35,6 +35,7 @@ const migrations = Object.entries(migrationFiles)
 export async function setupD1(): Promise<void> {
   await applyD1Migrations(env.DB, migrations);
   await env.DB.exec("DELETE FROM transcripts");
+  await env.DB.exec("DELETE FROM note_inbox");
   await env.DB.exec("DELETE FROM vault_files");
   await env.DB.exec("DELETE FROM vault_sync_batches");
 }


### PR DESCRIPTION
## Summary
- Add a D1-backed `note_inbox` queue for captured thoughts and Obsidian intake plans.
- Add the MCP tool `capture_thought` so Codex/ChatGPT-style clients can queue dumps, tasks, projects, people, and decisions.
- Add local bearer-protected sync endpoints: `GET /notes/pending`, `POST /notes/:id/synced`, and `POST /notes/capture`.
- Add `npm run notes:sync`, a local command that writes pending inbox items into the Obsidian vault, then acknowledges them after successful local writes.
- Document the hybrid workflow and add a Conductor track spec.

## Validation
- `npx tsc --noEmit`
- `npx vitest run`
- `npx wrangler deploy --dry-run --outdir dist --upload-source-maps`

## Notes
This intentionally keeps Obsidian writes local. Cloudflare stores the queue/context; the local sync command is the only piece that touches the vault filesystem.
